### PR TITLE
Switch to use the ‘mruby-pure-regexp’ gem for regular expression support

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,7 +3,7 @@ MRuby::Gem::Specification.new('mruby-marshal') do |spec|
   spec.author = 'take-cheeze'
   spec.summary = 'Marhshal module for mruby'
 
-  add_dependency 'mruby-onig-regexp', :github => 'mattn/mruby-onig-regexp'
+  add_dependency 'mruby-pure-regexp', :github => 'h2so5/mruby-pure-regexp'
   add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
   add_dependency 'mruby-struct', :core => 'mruby-struct'
 


### PR DESCRIPTION
The ‘mruby-onig-regexp’ gem has some problems building for iOS, depend
on the pure Ruby solution instead.